### PR TITLE
#46 Remove bang operator to eliminate Xcode warnings 

### DIFF
--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
@@ -13,6 +13,7 @@ import io.outfoxx.swiftpoet.CodeBlock
 import io.outfoxx.swiftpoet.EnumerationCaseSpec
 import io.outfoxx.swiftpoet.FunctionSpec
 import io.outfoxx.swiftpoet.Modifier
+import io.outfoxx.swiftpoet.ParameterizedTypeName
 import io.outfoxx.swiftpoet.PropertySpec
 import io.outfoxx.swiftpoet.TypeName
 import io.outfoxx.swiftpoet.TypeSpec
@@ -168,6 +169,85 @@ class SealedToSwiftEnumFeature(
         )
     }
 
+    private fun buildSealedProperty(
+        featureContext: ClassContext,
+        kotlinFrameworkName: String,
+        sealedCases: List<EnumCase>
+    ): PropertySpec {
+        val returnType: TypeName = featureContext.clazz.getDeclaredTypeNameWithGenerics(
+            kotlinFrameworkName = kotlinFrameworkName,
+            classes = featureContext.kLibClasses
+        )
+        return PropertySpec.builder("sealed", type = returnType)
+            .addModifiers(Modifier.PUBLIC)
+            .getter(
+                FunctionSpec
+                    .getterBuilder()
+                    .addCode(buildSealedPropertyBody(sealedCases, returnType))
+                    .build()
+            ).build()
+    }
+
+    private fun buildSealedPropertyBody(
+        sealedCases: List<EnumCase>,
+        returnType: TypeName
+    ): CodeBlock = CodeBlock.builder().apply {
+        add("switch self {\n")
+        sealedCases.forEach { enumCase ->
+            buildString {
+                append("case .")
+                append(enumCase.name)
+                append(enumCase.caseBlock)
+                append(":\n")
+            }.also { add(it) }
+            indent()
+            addSealedCaseReturnCode(enumCase, returnType)
+            unindent()
+        }
+        add("}\n")
+    }.build()
+
+    private fun CodeBlock.Builder.addSealedCaseReturnCode(
+        enumCase: EnumCase,
+        returnType: TypeName
+    ) {
+        val paramType: TypeName? = enumCase.param
+        val cast: String
+        val returnedName: String
+
+        if (paramType == null) {
+            returnedName = "${enumCase.caseArg}()"
+            cast = if (returnType is ParameterizedTypeName) {
+                // The return type is generic and there is no parameter, so it can
+                // be assumed that the case is NOT generic. Thus the case needs to
+                // be force-cast.
+                "as!"
+            } else {
+                // The return type is NOT generic and there is no parameter, so a
+                // regular cast can be used.
+                "as"
+            }
+        } else {
+            // There is a parameter
+            returnedName = "obj"
+            cast = if (paramType is ParameterizedTypeName && returnType is ParameterizedTypeName) {
+                if (paramType.typeArguments == returnType.typeArguments) {
+                    // The parameter and return type have the same generic pattern. This
+                    // is true if both are NOT generic OR if both are generic. Thus a
+                    // regular cast can be used.
+                    "as"
+                } else {
+                    "as!"
+                }
+            } else {
+                // If the parameter and return type have differing generic patterns
+                // then a force-cast is needed.
+                "as!"
+            }
+        }
+        add("return $returnedName $cast $returnType\n")
+    }
+
     data class EnumCase(
         val name: String,
         val param: TypeName?,
@@ -184,65 +264,6 @@ class SealedToSwiftEnumFeature(
                     EnumerationCaseSpec.builder(name, param)
                 }.build()
             }
-    }
-
-    private fun buildSealedProperty(
-        featureContext: ClassContext,
-        kotlinFrameworkName: String,
-        sealedCases: List<EnumCase>
-    ): PropertySpec {
-        val returnType: TypeName = featureContext.clazz.getDeclaredTypeNameWithGenerics(
-            kotlinFrameworkName = kotlinFrameworkName,
-            classes = featureContext.kLibClasses
-        )
-        return PropertySpec.builder(
-            "sealed", type = returnType
-        ).addModifiers(Modifier.PUBLIC)
-            .getter(
-                FunctionSpec.getterBuilder()
-                    .addCode(
-                        CodeBlock.builder().apply {
-                            /** A regex pattern that is used to match generic type parameters. E.g. `<T>` */
-                            val genericMatchingRegex = Regex("<.+?>")
-                            add("switch self {\n")
-                            sealedCases.forEach { enumCase ->
-                                buildString {
-                                    append("case .")
-                                    append(enumCase.name)
-                                    append(enumCase.caseBlock)
-                                    append(":\n")
-                                }.also { add(it) }
-                                indent()
-                                if (enumCase.param == null) {
-                                    if (genericMatchingRegex.containsMatchIn(returnType.toString())) {
-                                        // The return type is generic and there is no parameter, so it can
-                                        // be assumed that the case is NOT generic. Thus the case needs to
-                                        // be force-cast.
-                                        add("return ${enumCase.caseArg}() as! $returnType\n")
-                                    } else {
-                                        // The return type is NOT generic and there is no parameter, so a
-                                        // regular cast can be used.
-                                        add("return ${enumCase.caseArg}() as $returnType\n")
-                                    }
-                                } else {
-                                    // There is a parameter
-                                    if (genericMatchingRegex.find(enumCase.param.toString())?.value
-                                        == genericMatchingRegex.find(returnType.toString())?.value) {
-                                        // The parameter and return type have the same generic pattern. This
-                                        // is true if both are NOT generic OR if both are generic. Thus a
-                                        // regular cast can be used.
-                                        add("return obj as $returnType\n")
-                                    } else {
-                                        // If the parameter and return type have differing generic patterns
-                                        // then a force-cast is needed.
-                                        add("return obj as! $returnType\n")
-                                    }
-                                }
-                            }
-                            add("}\n")
-                        }.build()
-                    ).build()
-            ).build()
     }
 
     class Config : BaseConfig<ClassContext> {

--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
@@ -210,9 +210,9 @@ class SealedToSwiftEnumFeature(
                         }.also { add(it) }
                         indent()
                         if (enumCase.param == null) {
-                            add("return ${enumCase.caseArg}() as! $returnType\n")
+                            add("return ${enumCase.caseArg}() as $returnType\n")
                         } else {
-                            add("return obj as! $returnType\n")
+                            add("return obj as $returnType\n")
                         }
                         unindent()
                     }

--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
@@ -213,21 +213,26 @@ class SealedToSwiftEnumFeature(
                         indent()
                         if (enumCase.param == null) {
                             if (genericMatchingRegex.containsMatchIn(returnType.toString())) {
-                                // The return type is generic and there is no parameter, so it can be assumed that the case
-                                // is NOT generic. Thus the case needs to be force-cast.
+                                // The return type is generic and there is no parameter, so it can
+                                // be assumed that the case is NOT generic. Thus the case needs to
+                                // be force-cast.
                                 add("return ${enumCase.caseArg}() as! $returnType\n")
                             } else {
-                                // The return type is NOT generic and there is no parameter, so a regular cast can be used.
+                                // The return type is NOT generic and there is no parameter, so a
+                                // regular cast can be used.
                                 add("return ${enumCase.caseArg}() as $returnType\n")
                             }
                         } else {
                             // There is a parameter
-                            if (genericMatchingRegex.find(enumCase.param.toString())?.value == genericMatchingRegex.find(returnType.toString())?.value) {
-                                // The parameter and return type have the same generic pattern. This is true if both are
-                                // NOT generic OR if both are generic. Thus a regular cast can be used.
+                            if (genericMatchingRegex.find(enumCase.param.toString())?.value
+                                == genericMatchingRegex.find(returnType.toString())?.value) {
+                                // The parameter and return type have the same generic pattern. This
+                                // is true if both are NOT generic OR if both are generic. Thus a
+                                // regular cast can be used.
                                 add("return obj as $returnType\n")
                             } else {
-                                // If the parameter and return type have differing generic patterns then a force-cast is needed.
+                                // If the parameter and return type have differing generic patterns
+                                // then a force-cast is needed.
                                 add("return obj as! $returnType\n")
                             }
                         }

--- a/sample/ios-app/Tests/GenericSealedClassesToSwiftEnumTests.swift
+++ b/sample/ios-app/Tests/GenericSealedClassesToSwiftEnumTests.swift
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import XCTest
+@testable import MultiPlatformLibrary
+@testable import MultiPlatformLibrarySwift
+
+// ===> NEED TO GENERATE
+extension TestGenericSealedClass {
+    var withoutPropertyKs: GenericSealedClassKs<NSString, NSString> {
+        get {
+            return GenericSealedClassKs(self.withoutProperty)
+        }
+    }
+    var withOnePropertyTKs: GenericSealedClassKs<NSString, NSString> {
+        get {
+            return GenericSealedClassKs(self.withOnePropertyT)
+        }
+    }
+    var withOnePropertyUKs: GenericSealedClassKs<NSString, NSString> {
+        get {
+            return GenericSealedClassKs(self.withOnePropertyU)
+        }
+    }
+    var withTwoPropertiesKs: GenericSealedClassKs<NSString, NSString> {
+        get {
+            return GenericSealedClassKs(self.withTwoProperties)
+        }
+    }
+}
+// <=== NEED TO GENERATE
+
+class GenericSealedClassToSwiftEnumTests: XCTestCase {
+    private let testSource = TestGenericSealedClass()
+
+    func testWithoutProperty() throws {
+        if case .withoutProperty = testSource.withoutPropertyKs { } else { XCTFail() }
+        XCTAssertEqual(testSource.withoutPropertyKs.sealed, GenericSealedClassWithoutProperty())
+    }
+
+    func testWithOnePropertyT() throws {
+        if case .withOnePropertyT(let data) = testSource.withOnePropertyTKs {
+            XCTAssertEqual(data.value, "test")
+        } else { XCTFail() }
+        XCTAssertEqual(testSource.withOnePropertyTKs.sealed, GenericSealedClassWithOnePropertyT<NSString>(value: "test"))
+    }
+
+    func testWithOnePropertyU() throws {
+        if case .withOnePropertyU(let data) = testSource.withOnePropertyUKs {
+            XCTAssertEqual(data.value, "test")
+        } else { XCTFail() }
+        XCTAssertEqual(testSource.withOnePropertyUKs.sealed, GenericSealedClassWithOnePropertyU<NSString>(value: "test"))
+    }
+
+    func testWithTwoProperties() throws {
+        if case .withTwoProperties(let data) = testSource.withTwoPropertiesKs {
+            XCTAssertEqual(data.value1, "test1")
+            XCTAssertEqual(data.value2, "test2")
+        } else { XCTFail() }
+        XCTAssertEqual(testSource.withTwoPropertiesKs.sealed, GenericSealedClassWithTwoProperties<NSString, NSString>(value1: "test1", value2: "test2"))
+    }
+}

--- a/sample/ios-app/Tests/NonGenericSealedClassesToSwiftEnumTests.swift
+++ b/sample/ios-app/Tests/NonGenericSealedClassesToSwiftEnumTests.swift
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import XCTest
+@testable import MultiPlatformLibrary
+@testable import MultiPlatformLibrarySwift
+
+// ===> NEED TO GENERATE
+extension NonGenericSealedClass {
+    var withoutPropertyKs: NonGenericSealedClassKs {
+        get {
+            return NonGenericSealedClassKs(WithoutProperty())
+        }
+    }
+    var withPropertyKs: NonGenericSealedClassKs {
+        get {
+            return NonGenericSealedClassKs(WithProperty(value: "test"))
+        }
+    }
+}
+// <=== NEED TO GENERATE
+
+class NonGenericSealedClassToSwiftEnumTests: XCTestCase {
+    private let testSource = NonGenericSealedClass()
+
+    func testWithoutProperty() throws {
+        if case .withoutProperty = testSource.withoutPropertyKs { } else { XCTFail() }
+        XCTAssertEqual(testSource.withoutPropertyKs.sealed, NonGenericSealedClass.WithoutProperty())
+    }
+
+    func testWithProperty() throws {
+        if case .withProperty(let data) = testSource.withPropertyKs {
+            XCTAssertEqual(data.value, "test")
+        } else { XCTFail() }
+        XCTAssertEqual(testSource.withPropertyKs.sealed, NonGenericSealedClass.WithProperty(value: "test"))
+    }
+}

--- a/sample/ios-app/ios-app.xcodeproj/project.pbxproj
+++ b/sample/ios-app/ios-app.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		45F9E7F226D3E87A00233CAD /* AnyObjectSealedClassToEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F9E7F126D3E87A00233CAD /* AnyObjectSealedClassToEnum.swift */; };
 		65373AE744DF99D6120E6CD0 /* Pods_pods_test.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 170EAFB0A847A7E3A3CC557E /* Pods_pods_test.framework */; };
 		696500490BA3A16CF420DC2F /* Pods_ios_app_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D801D62C89CE2E003D435252 /* Pods_ios_app_Tests.framework */; };
+		D867A9A4284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867A9A3284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift */; };
+		D867A9A628490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +69,8 @@
 		9AACFD2445FE7D02ED352AD0 /* Pods-pods-test.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pods-test.release.xcconfig"; path = "Pods/Target Support Files/Pods-pods-test/Pods-pods-test.release.xcconfig"; sourceTree = "<group>"; };
 		A644D2F1C5377C40A53FCD6A /* Pods-ios-app.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-app.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-app/Pods-ios-app.release.xcconfig"; sourceTree = "<group>"; };
 		D801D62C89CE2E003D435252 /* Pods_ios_app_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_app_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D867A9A3284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonGenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
+		D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
 		DC187E7E0DAA30025ABCF8B8 /* Pods-ios-app-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-app-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-app-Tests/Pods-ios-app-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		DFBDF7D3559D080FDCA444A6 /* Pods-ios-app.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-app.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios-app/Pods-ios-app.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -146,6 +150,8 @@
 				4531D99F26BCEF93006F6A8A /* SealedInterfaceToSwiftEnumTests.swift */,
 				4531D9A126BCF698006F6A8A /* SealedClassToSwiftEnumTests.swift */,
 				45F9E7F126D3E87A00233CAD /* AnyObjectSealedClassToEnum.swift */,
+				D867A9A3284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift */,
+				D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -442,6 +448,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4531D9A226BCF698006F6A8A /* SealedClassToSwiftEnumTests.swift in Sources */,
+				D867A9A4284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift in Sources */,
+				D867A9A628490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift in Sources */,
 				4531D99626BAF83F006F6A8A /* PlatformExtensionsTests.swift in Sources */,
 				4531D9A026BCEF93006F6A8A /* SealedInterfaceToSwiftEnumTests.swift in Sources */,
 				45F9E7F226D3E87A00233CAD /* AnyObjectSealedClassToEnum.swift in Sources */,

--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/GenericSealedClass.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/GenericSealedClass.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package com.icerockdev.library
+
+/**
+ * This sealed class was created to test alongside the `NonGenericSealedClass` type to ensure that kswift
+ * creates the correct enum types for generic sealed classes with multiple type parameters.
+ */
+sealed class GenericSealedClass<out T, out U> {
+    /** A test `object` with no parameters and hard-coded types. */
+    object WithoutProperty : GenericSealedClass<Nothing, Nothing>()
+
+    /**
+     * A test `data class` with one parameter, one generic type, and one hard-coded type. Hard-codes
+     * the second type parameter (U).
+     */
+    data class WithOnePropertyT<T>(val value: T) : GenericSealedClass<T, Nothing>()
+
+    /**
+     * A test `data class` with one parameter, one generic type, and one hard-coded type. Hard-codes
+     * the first type parameter (T).
+     */
+    data class WithOnePropertyU<U>(val value: U) : GenericSealedClass<Nothing, U>()
+
+    /** A test `data class` with two parameters and two generic types. */
+    data class WithTwoProperties<T, U>(val value1: T, val value2: U) : GenericSealedClass<T, U>()
+}
+
+class TestGenericSealedClass {
+    val withoutProperty: GenericSealedClass<String, String> = GenericSealedClass.WithoutProperty
+    val withOnePropertyT: GenericSealedClass<String, String> = GenericSealedClass.WithOnePropertyT("test")
+    val withOnePropertyU: GenericSealedClass<String, String> = GenericSealedClass.WithOnePropertyU("test")
+    val withTwoProperties: GenericSealedClass<String, String> = GenericSealedClass.WithTwoProperties("test1", "test2")
+}

--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/NonGenericSealedClass.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/NonGenericSealedClass.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package com.icerockdev.library
+
+/**
+ * This sealed class was created to test alongside the `GenericSealedClass<T, U>` type to ensure that
+ * kswift creates the correct enum types for both generic and non-generic sealed classes.
+ */
+sealed class NonGenericSealedClass {
+    /** A test `object` that has no property. */
+    object WithoutProperty : NonGenericSealedClass()
+
+    /** A test `data class` with an associated value. */
+    data class WithProperty(val value: String) : NonGenericSealedClass()
+}


### PR DESCRIPTION
This PR was created to eliminate the following Xcode warning:

```
Forced cast from 'Class.dataclass1' to 'Class.dataclass2' always succeeds
```

### Update
It looks like my proposed fix of replacing `as!` with `as` breaks the sample app 😞.  My apologies.  This replacement seemed to resolve the issue with the project I'm on, but it may not be the way forward for everyone.