### PR TITLE
Fixes a small typo in the fatalError messages

### DIFF
--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
@@ -112,7 +112,7 @@ class SealedToSwiftEnumFeature(
                         }
                         add("} else {\n")
                         indent()
-                        add("fatalError(\"$className not syncronized with $originalClassName class\")\n")
+                        add("fatalError(\"$className not synchronized with $originalClassName class\")\n")
                         unindent()
                         add("}\n")
                     }


### PR DESCRIPTION
This PR fixes a small typo found in the `fatalError()` messages that are utilized across the types compiled by moko-kswift.