### PR TITLE
Fix Swift code generation for non nested sealed classes/interfaces

### DIFF
--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/SealedToSwiftEnumFeature.kt
@@ -146,7 +146,7 @@ class SealedToSwiftEnumFeature(
         val kmClass = featureContext.clazz
         val name: String = if (subclassName.startsWith(kmClass.name)) {
             subclassName.removePrefix(kmClass.name).removePrefix(".")
-        } else subclassName
+        } else subclassName.removePrefix(kmClass.name.substringBeforeLast("/")).removePrefix("/")
         val decapitalizedName: String = name.decapitalize(Locale.ROOT)
 
         val isObject: Boolean = Flag.Class.IS_OBJECT(sealedCaseClass.flags)

--- a/sample/ios-app/Tests/ExternalGenericSealedClassesToSwiftEnumTests.swift
+++ b/sample/ios-app/Tests/ExternalGenericSealedClassesToSwiftEnumTests.swift
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import XCTest
+@testable import MultiPlatformLibrary
+@testable import MultiPlatformLibrarySwift
+
+// ===> NEED TO GENERATE
+extension TestExternalGenericSealedClass {
+    var withoutPropertyKs: ExternalGenericSealedClassKs<NSString, NSString> {
+        get {
+            return ExternalGenericSealedClassKs(self.withoutProperty)
+        }
+    }
+    var withOnePropertyTKs: ExternalGenericSealedClassKs<NSString, NSString> {
+        get {
+            return ExternalGenericSealedClassKs(self.withOnePropertyT)
+        }
+    }
+    var withOnePropertyUKs: ExternalGenericSealedClassKs<NSString, NSString> {
+        get {
+            return ExternalGenericSealedClassKs(self.withOnePropertyU)
+        }
+    }
+    var withTwoPropertiesKs: ExternalGenericSealedClassKs<NSString, NSString> {
+        get {
+            return ExternalGenericSealedClassKs(self.withTwoProperties)
+        }
+    }
+}
+// <=== NEED TO GENERATE
+
+class ExternalGenericSealedClassToSwiftEnumTests: XCTestCase {
+    private let testSource = TestExternalGenericSealedClass()
+
+    func testWithoutProperty() throws {
+        if case .externalGenericWithoutProperty = testSource.withoutPropertyKs { } else { XCTFail() }
+        XCTAssertEqual(testSource.withoutPropertyKs.sealed, ExternalGenericWithoutProperty())
+    }
+
+    func testWithOnePropertyT() throws {
+        if case .externalGenericWithOnePropertyT(let data) = testSource.withOnePropertyTKs {
+            XCTAssertEqual(data.value, "test")
+        } else { XCTFail() }
+        XCTAssertEqual(testSource.withOnePropertyTKs.sealed, ExternalGenericWithOnePropertyT<NSString>(value: "test"))
+    }
+
+    func testWithOnePropertyU() throws {
+        if case .externalGenericWithOnePropertyU(let data) = testSource.withOnePropertyUKs {
+            XCTAssertEqual(data.value, "test")
+        } else { XCTFail() }
+        XCTAssertEqual(testSource.withOnePropertyUKs.sealed, ExternalGenericWithOnePropertyU<NSString>(value: "test"))
+    }
+
+    func testWithTwoProperties() throws {
+        if case .externalGenericWithTwoProperties(let data) = testSource.withTwoPropertiesKs {
+            XCTAssertEqual(data.value1, "test1")
+            XCTAssertEqual(data.value2, "test2")
+        } else { XCTFail() }
+        XCTAssertEqual(testSource.withTwoPropertiesKs.sealed, ExternalGenericWithTwoProperties<NSString, NSString>(value1: "test1", value2: "test2"))
+    }
+}

--- a/sample/ios-app/Tests/ExternalNonGenericSealedClassesToSwiftEnumTests.swift
+++ b/sample/ios-app/Tests/ExternalNonGenericSealedClassesToSwiftEnumTests.swift
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import XCTest
+@testable import MultiPlatformLibrary
+@testable import MultiPlatformLibrarySwift
+
+// ===> NEED TO GENERATE
+extension ExternalNonGenericSealedClass {
+    var withoutPropertyKs: ExternalNonGenericSealedClassKs {
+        get {
+            return ExternalNonGenericSealedClassKs(ExternalNonGenericWithoutProperty())
+        }
+    }
+    var withPropertyKs: ExternalNonGenericSealedClassKs {
+        get {
+            return ExternalNonGenericSealedClassKs(ExternalNonGenericWithProperty(value: "test"))
+        }
+    }
+}
+// <=== NEED TO GENERATE
+
+class ExternalNonGenericSealedClassToSwiftEnumTests: XCTestCase {
+    private let testSource = ExternalNonGenericSealedClass()
+
+    func testWithoutProperty() throws {
+        if case .externalNonGenericWithoutProperty = testSource.withoutPropertyKs { } else { XCTFail() }
+        XCTAssertEqual(testSource.withoutPropertyKs.sealed, ExternalNonGenericWithoutProperty())
+    }
+
+    func testWithProperty() throws {
+        if case .externalNonGenericWithProperty(let data) = testSource.withPropertyKs {
+            XCTAssertEqual(data.value, "test")
+        } else { XCTFail() }
+        XCTAssertEqual(testSource.withPropertyKs.sealed, ExternalNonGenericWithProperty(value: "test"))
+    }
+}

--- a/sample/ios-app/ios-app.xcodeproj/project.pbxproj
+++ b/sample/ios-app/ios-app.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		45F9E7F226D3E87A00233CAD /* AnyObjectSealedClassToEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F9E7F126D3E87A00233CAD /* AnyObjectSealedClassToEnum.swift */; };
 		65373AE744DF99D6120E6CD0 /* Pods_pods_test.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 170EAFB0A847A7E3A3CC557E /* Pods_pods_test.framework */; };
 		696500490BA3A16CF420DC2F /* Pods_ios_app_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D801D62C89CE2E003D435252 /* Pods_ios_app_Tests.framework */; };
+		A80C51F228FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80C51F128FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift */; };
+		A80C51F428FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80C51F328FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift */; };
 		D867A9A4284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867A9A3284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift */; };
 		D867A9A628490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */; };
 /* End PBXBuildFile section */
@@ -68,6 +70,8 @@
 		939B4E57FF3D22263AC6E0F6 /* Pods-ios-app-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-app-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios-app-Tests/Pods-ios-app-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		9AACFD2445FE7D02ED352AD0 /* Pods-pods-test.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pods-test.release.xcconfig"; path = "Pods/Target Support Files/Pods-pods-test/Pods-pods-test.release.xcconfig"; sourceTree = "<group>"; };
 		A644D2F1C5377C40A53FCD6A /* Pods-ios-app.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-app.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-app/Pods-ios-app.release.xcconfig"; sourceTree = "<group>"; };
+		A80C51F128FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalNonGenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
+		A80C51F328FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalGenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
 		D801D62C89CE2E003D435252 /* Pods_ios_app_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_app_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D867A9A3284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonGenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
 		D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
@@ -152,6 +156,8 @@
 				45F9E7F126D3E87A00233CAD /* AnyObjectSealedClassToEnum.swift */,
 				D867A9A3284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift */,
 				D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */,
+				A80C51F128FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift */,
+				A80C51F328FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -448,6 +454,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4531D9A226BCF698006F6A8A /* SealedClassToSwiftEnumTests.swift in Sources */,
+				A80C51F428FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift in Sources */,
+				A80C51F228FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift in Sources */,
 				D867A9A4284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift in Sources */,
 				D867A9A628490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift in Sources */,
 				4531D99626BAF83F006F6A8A /* PlatformExtensionsTests.swift in Sources */,

--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/ExternalGenericSealedClass.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/ExternalGenericSealedClass.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package com.icerockdev.library
+
+/**
+ * This sealed class was created to test alongside the [ExternalNonGenericSealedClass] type to ensure that kswift
+ * creates the correct enum types for generic sealed classes with multiple type parameters.
+ * Here, subclasses are defined out of the body of the parent class.
+ * See [GenericSealedClass] to see an example of nested subclasses
+ */
+sealed class ExternalGenericSealedClass<out T, out U>
+
+/** A test `object` with no parameters and hard-coded types. */
+object ExternalGenericWithoutProperty : ExternalGenericSealedClass<Nothing, Nothing>()
+
+/**
+ * A test `data class` with one parameter, one generic type, and one hard-coded type. Hard-codes
+ * the second type parameter (U).
+ */
+data class ExternalGenericWithOnePropertyT<T>(val value: T) :
+    ExternalGenericSealedClass<T, Nothing>()
+
+/**
+ * A test `data class` with one parameter, one generic type, and one hard-coded type. Hard-codes
+ * the first type parameter (T).
+ */
+data class ExternalGenericWithOnePropertyU<U>(val value: U) :
+    ExternalGenericSealedClass<Nothing, U>()
+
+/** A test `data class` with two parameters and two generic types. */
+data class ExternalGenericWithTwoProperties<T, U>(val value1: T, val value2: U) :
+    ExternalGenericSealedClass<T, U>()
+
+class TestExternalGenericSealedClass {
+    val withoutProperty: ExternalGenericSealedClass<String, String> = ExternalGenericWithoutProperty
+    val withOnePropertyT: ExternalGenericSealedClass<String, String> =
+        ExternalGenericWithOnePropertyT("test")
+    val withOnePropertyU: ExternalGenericSealedClass<String, String> =
+        ExternalGenericWithOnePropertyU("test")
+    val withTwoProperties: ExternalGenericSealedClass<String, String> =
+        ExternalGenericWithTwoProperties("test1", "test2")
+}

--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/ExternalNonGenericSealedClass.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/ExternalNonGenericSealedClass.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package com.icerockdev.library
+
+/**
+ * This sealed class was created to test alongside the [ExternalGenericSealedClass] type to ensure that
+ * kswift creates the correct enum types for both generic and non-generic sealed classes.
+ * Here, subclasses are defined out of the body of the parent class.
+ * See [NonGenericSealedClass] to see an example of nested subclasses
+ */
+sealed class ExternalNonGenericSealedClass
+
+/** A test `object` that has no property. */
+object ExternalNonGenericWithoutProperty : ExternalNonGenericSealedClass()
+
+/** A test `data class` with an associated value. */
+data class ExternalNonGenericWithProperty(val value: String) : ExternalNonGenericSealedClass()


### PR DESCRIPTION
Should fix Swift enum generation for nested sealed classes/interfaces.

The class prefix should also be removed to create the correct subclass name when the subclass and class prefixes are not the same.

I've added tests similar to the ones already provided for nested sealed classes, let me know if they are not enough.

Should close #64 and #43 