### PR TITLE
Add feature to generate improved copy method

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ mokoResourcesVersion = "0.16.2"
 kotlinxMetadataKLibVersion = "0.0.1"
 
 kotlinPoetVersion = "1.6.0"
-swiftPoetVersion = "1.3.1"
+swiftPoetVersion = "1.5.0"
 
 [libraries]
 appCompat = { module = "androidx.appcompat:appcompat", version.ref = "androidAppCompatVersion" }

--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/KmClassExt.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/KmClassExt.kt
@@ -12,6 +12,13 @@ import io.outfoxx.swiftpoet.parameterizedBy
 import kotlinx.metadata.ClassName
 import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmConstructor
+
+fun KmClass.isDataClass(): Boolean {
+    return Flag.Class.IS_DATA(flags)
+}
+
+fun KmClass.getPrimaryConstructor(): KmConstructor = constructors.getPrimaryConstructor()
 
 fun KmClass.buildTypeVariableNames(
     kotlinFrameworkName: String

--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/KmConstructorExt.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/KmConstructorExt.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2023 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.kswift.plugin
+
+import kotlinx.metadata.Flag
+import kotlinx.metadata.KmConstructor
+
+fun KmConstructor.isPrimary(): Boolean = Flag.Constructor.IS_SECONDARY(flags).not()
+
+fun List<KmConstructor>.getPrimaryConstructor(): KmConstructor = single { constructor -> constructor.isPrimary() }

--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/DataClassCopyFeature.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/DataClassCopyFeature.kt
@@ -97,6 +97,7 @@ class DataClassCopyFeature(
         val extensionSpec =
             ExtensionSpec.builder(TypeSpec.classBuilder(functionReturnType.name).build())
                 .addFunction(copyFunction)
+                .addDoc("selector: ${featureContext.prefixedUniqueId}")
                 .build()
 
         processorContext.fileSpecBuilder.addExtension(extensionSpec)

--- a/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/DataClassCopyFeature.kt
+++ b/kswift-gradle-plugin/src/main/kotlin/dev/icerock/moko/kswift/plugin/feature/DataClassCopyFeature.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.kswift.plugin.feature
+
+import dev.icerock.moko.kswift.plugin.buildTypeVariableNames
+import dev.icerock.moko.kswift.plugin.context.ClassContext
+import dev.icerock.moko.kswift.plugin.context.kLibClasses
+import dev.icerock.moko.kswift.plugin.getDeclaredTypeNameWithGenerics
+import dev.icerock.moko.kswift.plugin.getPrimaryConstructor
+import dev.icerock.moko.kswift.plugin.isDataClass
+import dev.icerock.moko.kswift.plugin.shouldUseKotlinTypeWhenHandlingOptionalType
+import dev.icerock.moko.kswift.plugin.toTypeName
+import io.outfoxx.swiftpoet.CodeBlock
+import io.outfoxx.swiftpoet.ExtensionSpec
+import io.outfoxx.swiftpoet.FunctionSpec
+import io.outfoxx.swiftpoet.FunctionTypeName
+import io.outfoxx.swiftpoet.ParameterSpec
+import io.outfoxx.swiftpoet.TypeSpec
+import io.outfoxx.swiftpoet.TypeVariableName
+import kotlinx.metadata.Flag
+import kotlinx.metadata.KmClass
+import kotlin.reflect.KClass
+
+/**
+ * Creates an improved copy method for data classes
+ */
+
+class DataClassCopyFeature(
+    override val featureContext: KClass<ClassContext>,
+    override val filter: Filter<ClassContext>
+) : ProcessorFeature<ClassContext>() {
+
+    @Suppress("ReturnCount")
+    override fun doProcess(featureContext: ClassContext, processorContext: ProcessorContext) {
+
+        val kotlinFrameworkName: String = processorContext.framework.baseName
+        val kmClass: KmClass = featureContext.clazz
+
+        if (Flag.IS_PUBLIC(kmClass.flags).not()) return
+
+        if (kmClass.isDataClass().not()) return
+
+        val typeVariables: List<TypeVariableName> =
+            kmClass.buildTypeVariableNames(kotlinFrameworkName)
+
+        // doesn't support generic data classes right now
+        if (typeVariables.isNotEmpty()) return
+
+        val functionReturnType = kmClass.getDeclaredTypeNameWithGenerics(
+            kotlinFrameworkName,
+            featureContext.kLibClasses
+        )
+
+        val constructorParameters = kmClass.getPrimaryConstructor().valueParameters
+
+        val functionParameters = constructorParameters.mapNotNull { parameter ->
+
+            val parameterType = parameter.type ?: return@mapNotNull null
+
+            ParameterSpec.builder(
+                parameterName = parameter.name,
+                type = FunctionTypeName.get(
+                    parameters = emptyList(),
+                    returnType = parameterType.toTypeName(
+                        moduleName = kotlinFrameworkName,
+                        isUsedInGenerics = parameterType.shouldUseKotlinTypeWhenHandlingOptionalType()
+                    ).run {
+                        if (Flag.Type.IS_NULLABLE(parameterType.flags)) {
+                            makeOptional()
+                        } else {
+                            this
+                        }
+                    }
+                ).makeOptional(),
+            ).defaultValue(
+                codeBlock = CodeBlock.builder().add("nil").build()
+            ).build()
+        }
+        val functionBody = constructorParameters.joinToString(separator = ",") { property ->
+            property.name.run {
+                "$this: ($this != nil) ? $this!() : self.$this"
+            }
+        }
+
+        val copyFunction = FunctionSpec.builder("copy")
+            .addParameters(functionParameters)
+            .returns(functionReturnType)
+            .addCode(
+                CodeBlock.builder()
+                    .addStatement("return %T($functionBody)", functionReturnType)
+                    .build()
+            )
+            .build()
+
+        val extensionSpec =
+            ExtensionSpec.builder(TypeSpec.classBuilder(functionReturnType.name).build())
+                .addFunction(copyFunction)
+                .build()
+
+        processorContext.fileSpecBuilder.addExtension(extensionSpec)
+    }
+
+    class Config : BaseConfig<ClassContext> {
+        override var filter: Filter<ClassContext> = Filter.Exclude(emptySet())
+    }
+
+    companion object : Factory<ClassContext, DataClassCopyFeature, Config> {
+        override fun create(block: Config.() -> Unit): DataClassCopyFeature {
+            val config = Config().apply(block)
+            return DataClassCopyFeature(featureContext, config.filter)
+        }
+
+        override val featureContext: KClass<ClassContext> = ClassContext::class
+
+        @JvmStatic
+        override val factory = Companion
+    }
+}

--- a/kswift-gradle-plugin/src/test/kotlin/dev/icerock/moko/kswift/plugin/PlatformExtensionsTest.kt
+++ b/kswift-gradle-plugin/src/test/kotlin/dev/icerock/moko/kswift/plugin/PlatformExtensionsTest.kt
@@ -61,16 +61,18 @@ class PlatformExtensionsTest {
         assertEquals(
             expected =
             """
-            public extension UIKit.UILabel {
-              /**
-               * test doc
-               */
-              @discardableResult
-              public func bindGenericText<T : Foundation.NSString>(liveData: shared.LiveData<T>) -> shared.Closeable {
-                return UILabelExtKt.bindGenericText(self, liveData: liveData as! shared.LiveData<Foundation.NSString>)
-              }
-            }
-            """.trimIndent(),
+    public extension UIKit.UILabel {
+    
+      /**
+       * test doc
+       */
+      @discardableResult
+      public func bindGenericText<T : Foundation.NSString>(liveData: shared.LiveData<T>) -> shared.Closeable {
+        return UILabelExtKt.bindGenericText(self, liveData: liveData as! shared.LiveData<Foundation.NSString>)
+      }
+    
+    }"""
+                .trimIndent(),
             actual = extensionSpec.toString().trim()
         )
     }
@@ -93,16 +95,18 @@ class PlatformExtensionsTest {
         assertEquals(
             expected =
             """
-            public extension UIKit.UILabel {
-              /**
-               * test doc
-               */
-              @discardableResult
-              public func bindGenericAny<T>(liveData: shared.LiveData<T>) -> shared.Closeable {
-                return UILabelExtKt.bindGenericAny(self, liveData: liveData as! shared.LiveData<Swift.AnyObject>)
-              }
-            }
-            """.trimIndent(),
+    public extension UIKit.UILabel {
+    
+      /**
+       * test doc
+       */
+      @discardableResult
+      public func bindGenericAny<T>(liveData: shared.LiveData<T>) -> shared.Closeable {
+        return UILabelExtKt.bindGenericAny(self, liveData: liveData as! shared.LiveData<Swift.AnyObject>)
+      }
+    
+    }"""
+                .trimIndent(),
             actual = extensionSpec.toString().trim()
         )
     }
@@ -152,16 +156,18 @@ class PlatformExtensionsTest {
         assertEquals(
             expected =
             """
-            public extension UIKit.UIControl {
-              /**
-               * test doc
-               */
-              @discardableResult
-              public func setEventHandler<T : UIKit.UIControl>(event: Swift.UInt64, lambda: @escaping (T) -> Swift.Void) -> shared.Closeable {
-                return UIControlExtKt.setEventHandler(self, event: event, lambda: lambda as! (UIKit.UIControl) -> Swift.Void)
-              }
-            }
-            """.trimIndent(),
+    public extension UIKit.UIControl {
+    
+      /**
+       * test doc
+       */
+      @discardableResult
+      public func setEventHandler<T : UIKit.UIControl>(event: Swift.UInt64, lambda: @escaping (T) -> Swift.Void) -> shared.Closeable {
+        return UIControlExtKt.setEventHandler(self, event: event, lambda: lambda as! (UIKit.UIControl) -> Swift.Void)
+      }
+    
+    }"""
+                .trimIndent(),
             actual = extensionSpec.toString().trim()
         )
     }
@@ -184,20 +190,22 @@ class PlatformExtensionsTest {
         assertEquals(
             expected =
             """
-            public extension Foundation.NotificationCenter {
-              /**
-               * test doc
-               */
-              @discardableResult
-              public func setEventHandler<T : Swift.AnyObject>(
-                notification: Swift.String,
-                ref: T,
-                lambda: @escaping (T) -> Swift.Void
-              ) -> shared.Closeable {
-                return NSNotificationCenterExtKt.setEventHandler(self, notification: notification, ref: ref, lambda: lambda as! (Swift.AnyObject) -> Swift.Void)
-              }
-            }
-            """.trimIndent(),
+    public extension Foundation.NotificationCenter {
+    
+      /**
+       * test doc
+       */
+      @discardableResult
+      public func setEventHandler<T : Swift.AnyObject>(
+        notification: Swift.String,
+        ref: T,
+        lambda: @escaping (T) -> Swift.Void
+      ) -> shared.Closeable {
+        return NSNotificationCenterExtKt.setEventHandler(self, notification: notification, ref: ref, lambda: lambda as! (Swift.AnyObject) -> Swift.Void)
+      }
+    
+    }"""
+                .trimIndent(),
             actual = extensionSpec.toString().trim()
         )
     }

--- a/sample/ios-app/Tests/DataClassCopyTests.swift
+++ b/sample/ios-app/Tests/DataClassCopyTests.swift
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import XCTest
+@testable import MultiPlatformLibrary
+@testable import MultiPlatformLibrarySwift
+
+/**
+ copy method needs to be generated
+ */
+class DataClassCopyTests: XCTestCase {
+    
+    func givenADataClassWhenUsingBetterCopyThenCheckThatProvidedArgumentsChangeRelatedPropertiesAndNotProvidedArgumentsPropertiesStayTheSame() throws {
+        let dataClass = DataClass(
+            stringValue: "aValue",
+            optionalStringValue: nil,
+            intValue: 0,
+            optionalIntValue: nil,
+            booleanValue: false,
+            optionalBooleanValue: nil
+            )
+        let dataClassWithNewValues = dataClass.copy(stringValue: {"aNewValue"}, intValue: {1}, booleanValue: {true})
+        XCTAssertEqual("aValue", dataClass.stringValue)
+        XCTAssertEqual("aNewValue", dataClassWithNewValues.stringValue)
+        XCTAssertEqual(dataClass.optionalStringValue, dataClassWithNewValues.optionalStringValue)
+        XCTAssertEqual(0, dataClass.intValue)
+        XCTAssertEqual(1, dataClassWithNewValues.intValue)
+        XCTAssertEqual(dataClass.optionalIntValue, dataClassWithNewValues.optionalIntValue)
+        XCTAssertFalse(dataClass.booleanValue)
+        XCTAssertTrue(dataClassWithNewValues.booleanValue)
+        XCTAssertEqual(dataClass.optionalBooleanValue, dataClassWithNewValues.optionalBooleanValue)
+    }
+    
+    func givenADataClassWhenUsingBetterCopyThenCheckThatProvidedArgumentsChangeRelatedOptionalPropertiesAndNotProvidedArgumentsPropertiesStayTheSame() throws {
+        let dataClass = DataClass(
+            stringValue: "aValue",
+            optionalStringValue: nil,
+            intValue: 0,
+            optionalIntValue: nil,
+            booleanValue: false,
+            optionalBooleanValue: nil
+            )
+        let dataClassWithNewValues = dataClass.copy(optionalStringValue: {"aNewOptionalValue"}, optionalIntValue: {1}, optionalBooleanValue: {true})
+        XCTAssertEqual(dataClass.stringValue, dataClassWithNewValues.stringValue)
+        XCTAssertEqual(nil, dataClass.optionalStringValue)
+        XCTAssertEqual("aNewOptionalValue", dataClassWithNewValues.optionalStringValue)
+        XCTAssertEqual(dataClass.intValue, dataClassWithNewValues.intValue)
+        XCTAssertEqual(nil, dataClass.optionalIntValue)
+        XCTAssertEqual(1, dataClassWithNewValues.optionalIntValue)
+        XCTAssertEqual(dataClass.booleanValue, dataClassWithNewValues.booleanValue)
+        XCTAssertNil(dataClass.optionalBooleanValue)
+        XCTAssertTrue(dataClassWithNewValues.optionalBooleanValue!.boolValue)
+    }
+    
+    func givenADataClassWhenUsingBetterCopyToSetAPropertyAsNilThenCheckThatIsPossibleToDoIt() throws {
+        let dataClass = DataClass(
+            stringValue: "aValue",
+            optionalStringValue: "aNonOptionalValue",
+            intValue: 0,
+            optionalIntValue: 10,
+            booleanValue: false,
+            optionalBooleanValue: true
+            )
+        let dataClassWithNewValues = dataClass.copy(optionalStringValue: {nil}, optionalIntValue: {nil}, optionalBooleanValue: {nil})
+        XCTAssertEqual(dataClass.stringValue, dataClassWithNewValues.stringValue)
+        XCTAssertEqual("aNonOptionalValue", dataClass.optionalStringValue)
+        XCTAssertNil(dataClassWithNewValues.optionalStringValue)
+        XCTAssertEqual(dataClass.intValue, dataClassWithNewValues.intValue)
+        XCTAssertEqual(10, dataClass.optionalIntValue)
+        XCTAssertNil(dataClassWithNewValues.optionalIntValue)
+        XCTAssertEqual(dataClass.booleanValue, dataClassWithNewValues.booleanValue)
+        XCTAssertTrue(dataClass.optionalBooleanValue!.boolValue)
+        XCTAssertNil(dataClassWithNewValues.optionalBooleanValue?.boolValue)
+    }
+    
+}

--- a/sample/ios-app/ios-app.xcodeproj/project.pbxproj
+++ b/sample/ios-app/ios-app.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		696500490BA3A16CF420DC2F /* Pods_ios_app_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D801D62C89CE2E003D435252 /* Pods_ios_app_Tests.framework */; };
 		A80C51F228FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80C51F128FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift */; };
 		A80C51F428FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80C51F328FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift */; };
+		A82612F029EC10910033ECF9 /* DataClassCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82612EF29EC10910033ECF9 /* DataClassCopyTests.swift */; };
 		D867A9A4284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867A9A3284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift */; };
 		D867A9A628490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */; };
 /* End PBXBuildFile section */
@@ -72,6 +73,7 @@
 		A644D2F1C5377C40A53FCD6A /* Pods-ios-app.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-app.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-app/Pods-ios-app.release.xcconfig"; sourceTree = "<group>"; };
 		A80C51F128FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalNonGenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
 		A80C51F328FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalGenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
+		A82612EF29EC10910033ECF9 /* DataClassCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataClassCopyTests.swift; sourceTree = "<group>"; };
 		D801D62C89CE2E003D435252 /* Pods_ios_app_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_app_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D867A9A3284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonGenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
 		D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSealedClassesToSwiftEnumTests.swift; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 				D867A9A528490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift */,
 				A80C51F128FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift */,
 				A80C51F328FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift */,
+				A82612EF29EC10910033ECF9 /* DataClassCopyTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -455,6 +458,7 @@
 			files = (
 				4531D9A226BCF698006F6A8A /* SealedClassToSwiftEnumTests.swift in Sources */,
 				A80C51F428FEF2DB00D9629E /* ExternalGenericSealedClassesToSwiftEnumTests.swift in Sources */,
+				A82612F029EC10910033ECF9 /* DataClassCopyTests.swift in Sources */,
 				A80C51F228FEF18A00D9629E /* ExternalNonGenericSealedClassesToSwiftEnumTests.swift in Sources */,
 				D867A9A4284852F40078FE14 /* NonGenericSealedClassesToSwiftEnumTests.swift in Sources */,
 				D867A9A628490D5F0078FE14 /* GenericSealedClassesToSwiftEnumTests.swift in Sources */,

--- a/sample/mpp-library/build.gradle.kts
+++ b/sample/mpp-library/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 kswift {
     install(dev.icerock.moko.kswift.plugin.feature.PlatformExtensionFunctionsFeature)
     install(dev.icerock.moko.kswift.plugin.feature.SealedToSwiftEnumFeature)
+    install(dev.icerock.moko.kswift.plugin.feature.DataClassCopyFeature)
 
     excludeLibrary("kotlinx-coroutines-core")
 

--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/DataClass.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/DataClass.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package com.icerockdev.library
+
+data class DataClass(
+    val stringValue: String,
+    val optionalStringValue: String?,
+    val intValue: Int,
+    val optionalIntValue: Int?,
+    val booleanValue: Boolean,
+    val optionalBooleanValue: Boolean?
+)

--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/DataClassWithCollections.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/DataClassWithCollections.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package com.icerockdev.library
+
+data class DataClassWithCollections(
+    val stringValues: List<String>,
+    val optionalStringValues: List<String>?,
+    val intValues: Set<Int>,
+    val optionalIntValues: Set<Int>?,
+    val booleanValues: Map<Int, Boolean>,
+    val optionalBooleanValues: Map<Int, Boolean>?
+)


### PR DESCRIPTION
When using this feature a new copy method will be generated for Kotlin data classes to be able to have an improved version of the copy method usable in the Swift code

Should close #61 when completed.

I open it as draft to have opinions on how to complete the work if we want to merge this feature 😄 

Attention points:
- ~~we might need to decide on the copy function name (now it's `betterCopy` to distinguish it from others)~~
- ~~we need to update swiftpoet to support optional closure, see outfoxx/swiftpoet#73~~
- ~~I've added some new code into `kotlinTypeNameToSwift` that might need double checks, but all tests run successfully~~
- at the moment it shouldn't support generic data classes (can be improved later)